### PR TITLE
Hardcode submodules to latest releases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,12 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
-	branch = v4.9.1
+	branch = v4.9.2
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+	branch = v4.9.2
 [submodule "lib/safe-contracts.git"]
 	path = lib/safe-contracts.git
 	url = https://github.com/safe-global/safe-contracts.git
+	branch = v1.4.1


### PR DESCRIPTION
Projects use master for the latest development code, and we only care about releases.
See https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable#foundry-git
for explanation.