### PR TITLE
Feat: Ironblocks Firewall Integration (First Draft)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/eigenlayer-middleware"]
 	path = lib/eigenlayer-middleware
 	url = https://github.com/Layr-Labs/eigenlayer-middleware.git
+[submodule "lib/ironblocks/onchain-firewall"]
+	path = lib/ironblocks/onchain-firewall
+	url = https://github.com/ironblocks/onchain-firewall

--- a/remappings.txt
+++ b/remappings.txt
@@ -9,6 +9,7 @@ eigenlayer/=lib/eigenlayer-contracts/src/contracts
 eigenlayer-middleware/=lib/eigenlayer-middleware/src/
 eigenlayer-test/=lib/eigenlayer-contracts/src/test
 openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+ironblocks/=lib/ironblocks/onchain-firewall/packages/
 puffer/=src/
 script/=script/
 rave/=lib/rave/src/


### PR DESCRIPTION
This pull request introduces Ironblocks' Firewall into Puffer's `PufferModule` contract.

Main changes are:

1. Import `BeaconProxyFirewallConsumer` which provides the `firewallProtected` modifier for upgradable contracts managed by a beacon proxy
2. Add the `firewallProtected` modifier to functions where protection is needed
3. Add overrides for context functions _(required to gracefully support multiple context imports)_

Additional information can also be found in our Documentation at:
https://docs.ironblocks.com/home

